### PR TITLE
Fix right handle behavior on click

### DIFF
--- a/RangeSlider.cpp
+++ b/RangeSlider.cpp
@@ -138,12 +138,14 @@ void RangeSlider::mousePressEvent(QMouseEvent* aEvent)
             mDelta = posValue - (secondHandleRectPosValue + scHandleSideLength / 2);
         }
 
-        if(posCheck >= 2
-           && posCheck <= posMax - 2)
+        else if(posCheck >= 2
+                && posCheck <= posMax - 2)
         {
             int step = mInterval / 10 < 1 ? 1 : mInterval / 10;
             if(posValue < firstHandleRectPosValue)
                 setLowerValue(mLowerValue - step);
+            else if(posValue > secondHandleRectPosValue + scHandleSideLength)
+                setUpperValue(mUpperValue + step);
             else if(((posValue > firstHandleRectPosValue + scHandleSideLength) || !type.testFlag(LeftHandle))
                     && ((posValue < secondHandleRectPosValue) || !type.testFlag(RightHandle)))
             {
@@ -157,9 +159,7 @@ void RangeSlider::mousePressEvent(QMouseEvent* aEvent)
                     setLowerValue((mLowerValue + step < mUpperValue) ? mLowerValue + step : mUpperValue);
                 else if(type.testFlag(RightHandle))
                     setUpperValue((mUpperValue - step > mLowerValue) ? mUpperValue - step : mLowerValue);
-            }
-            else if(posValue > secondHandleRectPosValue + scHandleSideLength)
-                setUpperValue(mUpperValue + step);
+            }            
         }
     }
 }


### PR DESCRIPTION
Fix #5

Here's a GIF with the fixed behavior:

![correct-right-slider](https://user-images.githubusercontent.com/1085180/78271770-f16b6680-74e2-11ea-91dc-65f6e636f397.gif)
